### PR TITLE
CreateConverter flags out parameter for future expansion

### DIFF
--- a/Examples/C/DataInspectorPluginExample/Int32Converter.c
+++ b/Examples/C/DataInspectorPluginExample/Int32Converter.c
@@ -48,7 +48,7 @@ typedef struct TInt32ConverterInstance {
 void* __stdcall CreateConverter(TConverterClassID ClassIDOrFactoryFunc,
     const wchar_t** TypeName, const wchar_t** FriendlyTypeName,
     TTypeCategory* Category, TDataTypeWidth* Width, int* MaxTypeSize,
-    TByteOrders* SupportedByteOrders, BOOL* SupportsStrToBytes)
+    TByteOrders* SupportedByteOrders, int* Flags)
 {
     // ClassIDOrFactoryFunc can be used to delegate creation to constructor
     // functions as needed. See the C++ plugin for an example.
@@ -63,7 +63,7 @@ void* __stdcall CreateConverter(TConverterClassID ClassIDOrFactoryFunc,
     *Width = dtwFixed;
     *MaxTypeSize = sizeof(int32_t);
     *SupportedByteOrders = 1 << boLittleEndian | 1 << boBigEndian;
-    *SupportsStrToBytes = TRUE;
+    *Flags = ccfSupportsStrToBytes;
 
     // create instance specific storage
     TInt32ConverterInstance* Converter = malloc(sizeof(TInt32ConverterInstance));

--- a/Interface/C++/DataInspectorPluginServer.cpp
+++ b/Interface/C++/DataInspectorPluginServer.cpp
@@ -21,7 +21,7 @@ void TExternalDataTypeConverter::Assign(TExternalDataTypeConverter* Source)
 void* __stdcall CreateConverter(TConverterClassID ClassIDOrFactoryFunc,
     const wchar_t** TypeName, const wchar_t** FriendlyTypeName,
     TTypeCategory* Category, TDataTypeWidth* Width, int* MaxTypeSize,
-    TByteOrders* SupportedByteOrders, BOOL* SupportsStrToBytes)
+    TByteOrders* SupportedByteOrders, int* Flags)
 {
     TExternalDataTypeConverterFactoryFunction FactoryFunc =
         (TExternalDataTypeConverterFactoryFunction)ClassIDOrFactoryFunc;
@@ -34,7 +34,7 @@ void* __stdcall CreateConverter(TConverterClassID ClassIDOrFactoryFunc,
     *Width = Converter->GetWidth();
     *MaxTypeSize = Converter->GetMaxTypeSize();
     *SupportedByteOrders = Converter->GetSupportedByteOrders();
-    *SupportsStrToBytes = Converter->GetSupportsStrToBytes();
+    *Flags = Converter->GetSupportsStrToBytes() ? ccfSupportsStrToBytes : 0;
 
     return Converter;
 }

--- a/Interface/C++/DataInspectorPluginServer.h
+++ b/Interface/C++/DataInspectorPluginServer.h
@@ -34,7 +34,7 @@ protected:
     TDataTypeWidth FWidth;
     int FMaxTypeSize;
     TByteOrders FSupportedByteOrders;
-    BOOL FSupportsStrToBytes;
+    bool FSupportsStrToBytes;
 
 private:
     std::wstring FLastReturnedString;
@@ -52,7 +52,7 @@ public:
     const TDataTypeWidth& GetWidth() { return FWidth; }
     const int& GetMaxTypeSize() { return FMaxTypeSize; }
     const TByteOrders& GetSupportedByteOrders() { return FSupportedByteOrders; }
-    const BOOL GetSupportsStrToBytes() { return FSupportsStrToBytes; }
+    const bool GetSupportsStrToBytes() { return FSupportsStrToBytes; }
 };
 
 

--- a/Interface/C/DataInspectorPluginInterface.h
+++ b/Interface/C/DataInspectorPluginInterface.h
@@ -20,7 +20,7 @@ void* __stdcall CreateConverter(
     TDataTypeWidth* Width,
     int* MaxTypeSize,
     TByteOrders* SupportedByteOrders,
-    BOOL* SupportsStrToBytes);
+    int* Flags);
 
 void __stdcall DestroyConverter(
     void* ThisPtr);

--- a/Interface/C/DataInspectorShared.h
+++ b/Interface/C/DataInspectorShared.h
@@ -62,6 +62,10 @@ typedef enum TBytesToIntError {
     btieNone, btieBytesTooShort
 } TBytesToIntError;
 
+typedef enum TCreateConverterFlags {
+    ccfSupportsStrToBytes = 0x00001
+} TCreateConverterFlags;
+
 typedef void* TConverterClassID;
 typedef TConverterClassID* PConverterClassID;
 

--- a/Interface/Delphi/DataInspectorPluginInterface.inc
+++ b/Interface/Delphi/DataInspectorPluginInterface.inc
@@ -22,7 +22,7 @@ function CreateConverter
   out Width: TDataTypeWidth;
   out MaxTypeSize: Integer;
   out SupportedByteOrders: TByteOrders;
-  out SupportsStrToBytes: LongBool): Pointer; stdcall;
+  out Flags: Integer): Pointer; stdcall;
 {$IFNDEF HXD_FUNC_PTRS}
   forward;
 {$ENDIF}

--- a/Interface/Delphi/DataInspectorPluginServer.pas
+++ b/Interface/Delphi/DataInspectorPluginServer.pas
@@ -111,7 +111,7 @@ function CreateConverter(ClassIDOrFactoryFunc: TConverterClassID; out TypeName,
   FriendlyTypeName: PWideChar; out Category: TTypeCategory;
   out Width: TDataTypeWidth; out MaxTypeSize: Integer;
   out SupportedByteOrders: TByteOrders;
-  out SupportsStrToBytes: LongBool): Pointer;
+  out Flags: Integer): Pointer;
 var
   Converter: TExternalDataTypeConverter;
 begin
@@ -123,7 +123,7 @@ begin
   Width := Converter.Width;
   MaxTypeSize := Converter.MaxTypeSize;
   SupportedByteOrders := Converter.SupportedByteOrders;
-  SupportsStrToBytes := Converter.SupportsStrToBytes;
+  Flags := IfThen(Converter.SupportsStrToBytes, ccfSupportsStrToBytes, 0);
 
   Result := Converter;
 end;

--- a/Interface/Delphi/DataInspectorShared.pas
+++ b/Interface/Delphi/DataInspectorShared.pas
@@ -38,6 +38,8 @@ type
 
   TBytesToIntError = (btieNone, btieBytesTooShort);
 
+  TCreateConverterFlags = (ccfSupportsStrToBytes = 0x00001);
+
   PConverterClassID = ^TConverterClassID;
   TConverterClassID = type Pointer;
 


### PR DESCRIPTION
This converts the DataInspector SupportsStrToBytes output parameter to a flags parameter for future expansion.

This slightly breaks ABI if somebody had code that does `*SupportsStrToBytes = 2` instead of true/false but this is a non-issue since the current plug-in API is already ABI incompatible with the current HxD release (2.5.0.0).